### PR TITLE
Add ChartName internal resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/giantswarm/apiextensions/v3 v3.22.0
+	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/exporterkit v0.2.1
 	github.com/giantswarm/k8sclient/v5 v5.11.0
 	github.com/giantswarm/k8smetadata v0.3.0

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -18,11 +18,13 @@ import (
 	"github.com/giantswarm/cluster-apps-operator/pkg/project"
 	"github.com/giantswarm/cluster-apps-operator/service/controller/resource/appversionlabel"
 	"github.com/giantswarm/cluster-apps-operator/service/controller/resource/clusterconfigmap"
+	"github.com/giantswarm/cluster-apps-operator/service/internal/chartname"
 	"github.com/giantswarm/cluster-apps-operator/service/internal/podcidr"
 	"github.com/giantswarm/cluster-apps-operator/service/internal/releaseversion"
 )
 
 type ClusterConfig struct {
+	ChartName      chartname.Interface
 	K8sClient      k8sclient.Interface
 	Logger         micrologger.Logger
 	ReleaseVersion releaseversion.Interface

--- a/service/internal/chartname/chart_name.go
+++ b/service/internal/chartname/chart_name.go
@@ -1,0 +1,161 @@
+package chartname
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/apiextensions/v3/pkg/clientset/versioned"
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/giantswarm/cluster-apps-operator/service/internal/chartname/internal/cache"
+)
+
+const (
+	httpClientTimeout = 10 * time.Second
+)
+
+type Config struct {
+	G8sClient versioned.Interface
+	Logger    micrologger.Logger
+}
+
+type ChartName struct {
+	g8sClient  versioned.Interface
+	httpClient *http.Client
+	indexCache *cache.Index
+	logger     micrologger.Logger
+}
+
+func New(c Config) (*ChartName, error) {
+	if c.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", c)
+	}
+	if c.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", c)
+	}
+
+	// Set client timeout to prevent leakages.
+	httpClient := &http.Client{
+		Timeout: httpClientTimeout,
+	}
+
+	cn := &ChartName{
+		g8sClient:  c.G8sClient,
+		httpClient: httpClient,
+		indexCache: cache.NewIndex(),
+		logger:     c.Logger,
+	}
+
+	return cn, nil
+}
+
+// ChartName returns the name of the chart as it appears in the index.yaml
+// for the catalog.
+func (cn *ChartName) ChartName(ctx context.Context, catalogName, appName, appVersion string) (string, error) {
+	var index catalogIndex
+
+	index, err := cn.cachedCatalogIndex(ctx, catalogName)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	appNameWithoutAppSuffix := strings.TrimSuffix(appName, "-app")
+	appNameWithAppSuffix := fmt.Sprintf("%s-app", appNameWithoutAppSuffix)
+	chartName := ""
+
+	entries, ok := index.Entries[appNameWithAppSuffix]
+	if !ok || len(entries) == 0 {
+		entries, ok = index.Entries[appNameWithoutAppSuffix]
+		if !ok || len(entries) == 0 {
+			return "", microerror.Maskf(notFoundError, "could not find chart %s in %s catalog", appName, catalogName)
+		}
+		chartName = appNameWithoutAppSuffix
+	} else {
+		chartName = appNameWithAppSuffix
+	}
+
+	for _, entry := range entries {
+		if entry.Version == appVersion && entry.Name == chartName {
+			return entry.Name, nil
+		}
+	}
+
+	return "", microerror.Maskf(notFoundError, "could not find chart %s in %s catalog", appName, catalogName)
+}
+
+func (cn *ChartName) cachedCatalogIndex(ctx context.Context, catalogName string) (catalogIndex, error) {
+	var index catalogIndex
+	var err error
+
+	var catalog *applicationv1alpha1.AppCatalog
+	{
+		catalog, err = cn.g8sClient.ApplicationV1alpha1().AppCatalogs().Get(ctx, catalogName, metav1.GetOptions{})
+		if err != nil {
+			return index, microerror.Mask(err)
+		}
+	}
+
+	{
+		indexYaml, ok := cn.indexCache.Get(ctx, catalogName)
+		if !ok {
+			indexYaml, err = cn.fetchCatalogIndex(ctx, catalogName, catalog.Spec.Storage.URL)
+			if err != nil {
+				return index, microerror.Mask(err)
+			}
+
+			cn.indexCache.Set(ctx, catalogName, indexYaml)
+		}
+
+		err = yaml.Unmarshal(indexYaml, &index)
+		if err != nil {
+			return index, microerror.Mask(err)
+		}
+	}
+
+	return index, nil
+}
+
+func (cn *ChartName) fetchCatalogIndex(ctx context.Context, catalogName, catalogURL string) ([]byte, error) {
+	var err error
+
+	url := strings.TrimRight(catalogURL, "/") + "/index.yaml"
+	body := []byte{}
+
+	o := func() error {
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, &bytes.Buffer{}) // nolint: gosec
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		response, err := cn.httpClient.Do(request)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		defer response.Body.Close()
+
+		body, err = ioutil.ReadAll(response.Body)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		return nil
+	}
+	b := backoff.NewExponential(30*time.Second, 5*time.Second)
+	n := backoff.NewNotifier(cn.logger, ctx)
+
+	err = backoff.RetryNotify(o, b, n)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return body, nil
+}

--- a/service/internal/chartname/error.go
+++ b/service/internal/chartname/error.go
@@ -1,0 +1,21 @@
+package chartname
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/internal/chartname/internal/cache/cache.go
+++ b/service/internal/chartname/internal/cache/cache.go
@@ -1,0 +1,7 @@
+package cache
+
+import "time"
+
+const (
+	expiration = 5 * time.Minute
+)

--- a/service/internal/chartname/internal/cache/index.go
+++ b/service/internal/chartname/internal/cache/index.go
@@ -1,0 +1,32 @@
+package cache
+
+import (
+	"context"
+
+	gocache "github.com/patrickmn/go-cache"
+)
+
+type Index struct {
+	cache *gocache.Cache
+}
+
+func NewIndex() *Index {
+	i := &Index{
+		cache: gocache.New(expiration, expiration/2),
+	}
+
+	return i
+}
+
+func (i *Index) Get(ctx context.Context, key string) ([]byte, bool) {
+	val, ok := i.cache.Get(key)
+	if ok {
+		return val.([]byte), true
+	}
+
+	return nil, false
+}
+
+func (i *Index) Set(ctx context.Context, key string, val []byte) {
+	i.cache.SetDefault(key, val)
+}

--- a/service/internal/chartname/spec.go
+++ b/service/internal/chartname/spec.go
@@ -1,0 +1,11 @@
+package chartname
+
+import (
+	"context"
+)
+
+type Interface interface {
+	// ChartName returns the name of the chart as it appears in the index.yaml
+	// for the catalog.
+	ChartName(ctx context.Context, catalogName, appName, appVersion string) (string, error)
+}

--- a/service/internal/chartname/types.go
+++ b/service/internal/chartname/types.go
@@ -1,0 +1,10 @@
+package chartname
+
+type catalogIndex struct {
+	Entries map[string][]indexEntry `json:"entries"`
+}
+
+type indexEntry struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}


### PR DESCRIPTION
Towards giantswarm/roadmap#320

This is prep for adding the app resource. I simplified it by extracting the logic to check the chart name.

This checks if the chart name has the `-app` suffix. We also now cache the index.yaml for the catalog.

