### PR TITLE
Include both namespace and cluster CR name in log messages

### DIFF
--- a/service/controller/resource/app/current.go
+++ b/service/controller/resource/app/current.go
@@ -21,7 +21,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) ([]*v1a
 
 	var apps []*v1alpha1.App
 	{
-		r.logger.Debugf(ctx, "finding apps for workload cluster %#q", key.ClusterID(&cr))
+		r.logger.Debugf(ctx, "finding apps for cluster '%s/%s'", cr.GetNamespace(), key.ClusterID(&cr))
 
 		o := metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, project.Name()),
@@ -36,7 +36,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) ([]*v1a
 			apps = append(apps, item.DeepCopy())
 		}
 
-		r.logger.Debugf(ctx, "found %d apps for workload cluster %#q", len(apps), key.ClusterID(&cr))
+		r.logger.Debugf(ctx, "found %d apps for cluster '%s/%s'", len(apps), cr.GetNamespace(), key.ClusterID(&cr))
 	}
 
 	return apps, nil

--- a/service/controller/resource/app/desired.go
+++ b/service/controller/resource/app/desired.go
@@ -27,7 +27,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*app
 	var apps []*applicationv1alpha1.App
 
 	if key.IsDeleted(&cr) {
-		r.logger.Debugf(ctx, "deleting apps for workload cluster %#q", key.ClusterID(&cr))
+		r.logger.Debugf(ctx, "deleting apps for cluster '%s/%s'", cr.GetNamespace(), key.ClusterID(&cr))
 		return apps, nil
 	}
 

--- a/service/controller/resource/appversionlabel/create.go
+++ b/service/controller/resource/appversionlabel/create.go
@@ -26,7 +26,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	var apps []*v1alpha1.App
 	{
-		r.logger.Debugf(ctx, "finding optional apps for workload cluster %#q", key.ClusterID(&cr))
+		r.logger.Debugf(ctx, "finding optional apps for cluster '%s/%s'", cr.GetNamespace(), key.ClusterID(&cr))
 
 		o := metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s!=%s", label.ManagedBy, project.Name()),
@@ -40,7 +40,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			apps = append(apps, item.DeepCopy())
 		}
 
-		r.logger.Debugf(ctx, "found %d optional apps for workload cluster %#q", len(apps), key.ClusterID(&cr))
+		r.logger.Debugf(ctx, "found %d optional apps for cluster '%s/%s'", len(apps), cr.GetNamespace(), key.ClusterID(&cr))
 
 		if len(apps) == 0 {
 			// Return early as there is nothing to do.
@@ -62,7 +62,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Maskf(notFoundError, "app-operator component version not found")
 		}
 
-		r.logger.Debugf(ctx, "updating version label for optional apps in workload cluster %#q", key.ClusterID(&cr))
+		r.logger.Debugf(ctx, "updating version label for optional apps in cluster '%s/%s'", cr.GetNamespace(), key.ClusterID(&cr))
 
 		for _, app := range apps {
 			currentVersion := app.Labels[label.AppOperatorVersion]
@@ -99,9 +99,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		if updatedAppCount > 0 {
-			r.logger.Debugf(ctx, "updating version label for %d optional apps in workload cluster %#q", updatedAppCount, key.ClusterID(&cr))
+			r.logger.Debugf(ctx, "updating version label for %d optional apps in cluster '%s/%s'", updatedAppCount, cr.GetNamespace(), key.ClusterID(&cr))
 		} else {
-			r.logger.Debugf(ctx, "no version labels to update for workload cluster %#q", key.ClusterID(&cr))
+			r.logger.Debugf(ctx, "no version labels to update for cluster '%s/%s'", cr.GetNamespace(), key.ClusterID(&cr))
 		}
 	}
 

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -25,7 +25,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 	var configMaps []*corev1.ConfigMap
 
 	if key.IsDeleted(&cr) {
-		r.logger.Debugf(ctx, "deleting cluster configmaps for workload cluster %#q", key.ClusterID(&cr))
+		r.logger.Debugf(ctx, "deleting cluster configmaps for cluster '%s/%s'", cr.GetNamespace(), key.ClusterID(&cr))
 		return configMaps, nil
 	}
 


### PR DESCRIPTION
Changes log messages to use the format '[namespace]/[cluster]' since CAPI CRs are moving to the organization namespace.

Also shortens `workload cluster` to `cluster`.