### PR TITLE
Don't remove App CR finalizer if it has not been deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Check upstream CAPI cluster name label as well as Giant Swarm label.
 
+### Fixed
+
+- Don't remove App CR finalizer if it has not been deleted.
+
 ## [0.2.0] - 2021-08-09
 
 ### Added

--- a/service/controller/resource/appfinalizer/delete.go
+++ b/service/controller/resource/appfinalizer/delete.go
@@ -65,6 +65,11 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	r.logger.Debugf(ctx, "found %d apps to remove finalizers for", len(list.Items))
 
 	for _, app := range list.Items {
+		if app.DeletionTimestamp == nil {
+			r.logger.Debugf(ctx, "skipping removal of finalizer for app %#q as it is not deleted", app.Name)
+			continue
+		}
+
 		r.logger.Debugf(ctx, "removing finalizer for app %#q", app.Name)
 
 		index := getFinalizerIndex(app.Finalizers)


### PR DESCRIPTION
See https://gigantic.slack.com/archives/C01F7T2MNRL/p1629451526008200

We shouldn't try to remove the finalizer until the app CRs have been deleted.

```
D 08/23 10:56:43 org-giantswarm/capz-jose appfinalizer finding apps to remove finalizers for | cluster-apps-operator/service/controller/resource/appfinalizer/delete.go:58 | controller=cluster-apps-operator-cluster-controller | event=delete | loop=89 | version=112269288                                                                                                                                                                                                           
D 08/23 10:56:43 org-giantswarm/capz-jose appfinalizer found 11 apps to remove finalizers for | cluster-apps-operator/service/controller/resource/appfinalizer/delete.go:65 | controller=cluster-apps-operator-cluster-controller | event=delete | loop=89 | version=112269288                                                                                                                                                                                                          
D 08/23 10:56:43 org-giantswarm/capz-jose appfinalizer removing finalizer for app `azure-scheduled-events` | cluster-apps-operator/service/controller/resource/appfinalizer/delete.go:68 | controller=cluster-apps-operator-cluster-controller | event=delete | loop=89 | version=112269288                                                                                                                                                                                             
E 08/23 10:56:43 org-giantswarm/capz-jose appfinalizer retrying due to error | operatorkit/v4/pkg/resource/wrapper/retryresource/basic_resource.go:83 | controller=cluster-apps-operator-cluster-controller | event=delete | loop=89 | version=112269288                                                                                                                                                                                                                                
        /go/pkg/mod/github.com/giantswarm/operatorkit/v4@v4.3.1/pkg/resource/wrapper/retryresource/basic_resource.go:76
        /root/project/service/controller/resource/appfinalizer/delete.go:85
        unknown: admission webhook "apps.app-admission-controller.giantswarm.io" denied the request: kube config not found error: kubeconfig secret `capz-jose-kubeconfig` in namespace `org-giantswarm` not found
```


## Checklist

- [x] Update changelog in CHANGELOG.md.


