### PR TITLE
add-provider-value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add provider to the cluster values configmap.
+
 ## [0.5.0] - 2021-08-30
 
 ### Added

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -75,11 +75,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		switch infrastructureRef.Kind {
 		case "AWSCluster":
 			provider = "aws"
-			break
 
 		case "AzureCluster":
 			provider = "azure"
-			break
 
 		default:
 			provider = "unknown"

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -68,6 +68,24 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		}
 	}
 
+	var provider string
+	{
+		infrastructureRef := cr.Spec.InfrastructureRef
+
+		switch infrastructureRef.Kind {
+		case "AWSCluster":
+			provider = "aws"
+			break
+
+		case "AzureCluster":
+			provider = "azure"
+			break
+
+		default:
+			provider = "unknown"
+		}
+	}
+
 	configMapSpecs := []configMapSpec{
 		{
 			Name:      key.ClusterConfigMapName(&cr),
@@ -95,6 +113,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 				"clusterDNSIP": r.dnsIP,
 				"clusterID":    key.ClusterID(&cr),
 				"clusterCIDR":  clusterCIDR,
+				"provider":     provider,
 			},
 		},
 	}


### PR DESCRIPTION
add provider value to the cluster configmap

we need this value in order to properly render `calico-policy-only` app which is used for both `AWS` and `Azure`

## Checklist

- [x] Update changelog in CHANGELOG.md.


used https://github.com/giantswarm/cluster-apps-operator/pull/95 as template for the changes