### PR TITLE
Keep cluster CR finalizer until app CRs have been deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep cluster CR finalizer until app CRs have been deleted.
+
 ## [0.6.0] - 2021-08-31
 
 - Add provider to the cluster values configmap.

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -218,9 +218,6 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 	}
 
 	resources := []resource.Interface{
-		// appFinalizerResource is executed first and removes finalizers after
-		// the per cluster app-operator instance has been deleted.
-		appFinalizerResource,
 		// clusterNamespace manages the namespace for storing app related
 		// resources for this cluster.
 		clusterNamespaceResource,
@@ -230,6 +227,9 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 		// appResource manages the per cluster app-operator instance and the
 		// workload cluster apps.
 		appResource,
+		// appFinalizerResource removes finalizers after the per cluster
+		// app-operator instance has been deleted.
+		appFinalizerResource,
 		// appVersionLabel resource ensures the version label is correct for
 		// optional app CRs.
 		appVersionLabelResource,


### PR DESCRIPTION
This is a fix for a problem with cluster deletion reported by @nprokopic 
https://gigantic.slack.com/archives/C0251MXL5/p1631176814021100

The cluster namespace was stuck in terminating because the cluster CR finalizer had been removed but there were still app CRs with the app-operator finalizer.

## Checklist

- [x] Update changelog in CHANGELOG.md.
