### PR TITLE
Filter Cluster events by watching label instead of operator version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Adjust label selector to watch all Clusters with an organization label instead of those matching the current operator version to
-allow the operator to be deployed in the app collection instead of by release-operator. Watching clusters with an organization label
-ensures that self-managed MCs (containing their own Cluster CR) won't overwrite their own apps.
+- Adjust label selector to watch all Clusters with any `cluster-apps-operator.giantswarm.io/version`
+  label instead of those matching the current operator version to allow the operator to be 
+  deployed in the app collection instead of by `release-operator`.
 
 ## [1.0.0] - 2021-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Adjust label selector to watch all Clusters with any `cluster-apps-operator.giantswarm.io/version`
+- Adjust label selector to watch all Clusters with any `cluster-apps-operator.giantswarm.io/watching`
   label instead of those matching the current operator version to allow the operator to be 
   deployed in the app collection instead of by `release-operator`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix RBAC permissions for creating secrets and getting OpenStack clusters.
+
+### Changed
+
+- Adjust label selector to watch all Clusters with an organization label instead of those matching the current operator version to
+allow the operator to be deployed in the app collection instead of by release-operator. Watching clusters with an organization label
+ensures that self-managed MCs (containing their own Cluster CR) won't overwrite their own apps.
+
 ## [1.0.0] - 2021-12-03
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/exporterkit v0.2.1
 	github.com/giantswarm/k8sclient/v6 v6.0.0
-	github.com/giantswarm/k8smetadata v0.6.0
+	github.com/giantswarm/k8smetadata v0.7.1
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/microkit v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,9 @@ github.com/giantswarm/exporterkit v0.2.1/go.mod h1:LkZNK+2qTcbHspbizA6JBBXpQW99u
 github.com/giantswarm/k8sclient/v6 v6.0.0 h1:jVrB8/q12/yPDv/tv8cwj4Z11hFGvGuNO2n9O1s+xGo=
 github.com/giantswarm/k8sclient/v6 v6.0.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7CP3GoaFsfZ5KHps=
 github.com/giantswarm/k8smetadata v0.5.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
-github.com/giantswarm/k8smetadata v0.6.0 h1:L3opjzcNzetPacI4zOcYxDAvp6ssM/QLfuXZTQ5Otyo=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
+github.com/giantswarm/k8smetadata v0.7.1 h1:Wc49mhisTc1BgaDGEPtnP7VCozuoa3DI/Txx4p++sdo=
+github.com/giantswarm/k8smetadata v0.7.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=
 github.com/giantswarm/microendpoint v0.2.0/go.mod h1:SSkSp4Q4iSW7vwkil+/E3IXy9Q8To8vXmT5VCg24RDg=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=

--- a/helm/cluster-apps-operator/templates/rbac.yaml
+++ b/helm/cluster-apps-operator/templates/rbac.yaml
@@ -94,6 +94,7 @@ rules:
       - infrastructure.cluster.x-k8s.io
     resources:
       - azureclusters
+      - openstackclusters
     verbs:
       - "get"
   - nonResourceURLs:

--- a/helm/cluster-apps-operator/templates/rbac.yaml
+++ b/helm/cluster-apps-operator/templates/rbac.yaml
@@ -45,6 +45,7 @@ rules:
     resources:
       - configmaps
       - namespaces
+      - secrets
     verbs:
       - create
       - update

--- a/helm/cluster-apps-operator/values.yaml
+++ b/helm/cluster-apps-operator/values.yaml
@@ -54,7 +54,7 @@ release:
         chart-operator:
           chart:     "chart-operator"
           namespace: "giantswarm"
-        cloud-provider-openstack-app:
+        cloud-provider-openstack:
           hasClusterValuesSecret: true
         # Upgrade force is disabled to avoid affecting customer workloads.
         coredns:

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/metricsresource"
 	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/retryresource"
 	"github.com/giantswarm/resource/v4/appresource"
+	"k8s.io/apimachinery/pkg/labels"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -69,6 +70,9 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 			// Name is used to compute finalizer names. This here results in something
 			// like operatorkit.giantswarm.io/cluster-apps-operator-cluster-controller.
 			Name: project.Name() + "-cluster-controller",
+			Selector: labels.SelectorFromSet(map[string]string{
+				label.ManagedBy: project.Name(),
+			}),
 		}
 
 		operatorkitController, err = controller.New(c)

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -59,7 +59,7 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 
 	var operatorkitController *controller.Controller
 	{
-		selector, err := labels.Parse(label.Organization)
+		selector, err := labels.Parse(label.ClusterAppsOperatorVersion)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -59,7 +59,7 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 
 	var operatorkitController *controller.Controller
 	{
-		selector, err := labels.Parse(label.ClusterAppsOperatorVersion)
+		selector, err := labels.Parse(label.ClusterAppsOperatorWatching)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -59,6 +59,11 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 
 	var operatorkitController *controller.Controller
 	{
+		selector, err := labels.Parse(label.Organization)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
 		c := controller.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
@@ -69,10 +74,8 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 
 			// Name is used to compute finalizer names. This here results in something
 			// like operatorkit.giantswarm.io/cluster-apps-operator-cluster-controller.
-			Name: project.Name() + "-cluster-controller",
-			Selector: labels.SelectorFromSet(map[string]string{
-				label.ManagedBy: project.Name(),
-			}),
+			Name:     project.Name() + "-cluster-controller",
+			Selector: selector,
 		}
 
 		operatorkitController, err = controller.New(c)

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/metricsresource"
 	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/retryresource"
 	"github.com/giantswarm/resource/v4/appresource"
-	"k8s.io/apimachinery/pkg/labels"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -70,9 +69,6 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 			// Name is used to compute finalizer names. This here results in something
 			// like operatorkit.giantswarm.io/cluster-apps-operator-cluster-controller.
 			Name: project.Name() + "-cluster-controller",
-			Selector: labels.SelectorFromSet(map[string]string{
-				label.ClusterAppsOperatorVersion: project.Version(),
-			}),
 		}
 
 		operatorkitController, err = controller.New(c)


### PR DESCRIPTION
In the post-CAPI world, we will have a single operator watching CRs instead of using label filtering (aka VOO). This is a breaking change, but will be needed for all providers when they are ready. Only OpenStack is using v1.0.0 so I'm not releasing this as a new major version.

Also includes minor fixes from testing.

## Checklist

- [x] Update changelog in CHANGELOG.md.
