### PR TITLE
Set `dns.service=kube-dns` for `net-exporter` in CAPO cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Set `dns.service=kube-dns` for `net-exporter` in CAPO cluster.
 - Add the `cluster_apps_operator_cluster_dangling_apps` metric for detecting not yet deleted apps.
 
 ### Changed
@@ -44,7 +45,7 @@ versioned via the operator's configmap.
 ### Changed
 
 - Adjust label selector to watch all Clusters with any `cluster-apps-operator.giantswarm.io/watching`
-  label instead of those matching the current operator version to allow the operator to be 
+  label instead of those matching the current operator version to allow the operator to be
   deployed in the app collection instead of by `release-operator`.
 
 ## [1.0.0] - 2021-12-03

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -108,6 +108,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 
 			case "OpenStackCluster":
 				clusterValues["provider"] = "openstack"
+				clusterValues["dns"] = map[string]interface{}{
+					"service": "kube-dns",
+				}
 
 			case "VSphereCluster":
 				clusterValues["provider"] = "vsphere"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/725

We need to configure net-exporter from default-apps-openstack to use the correct service. This is very indirect. I truly believe we should split this CM as I already expressed multiple times.