### PR TITLE
Use backoff when installing App

### DIFF
--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -58,7 +58,7 @@ func installResources(ctx context.Context, config Config) error {
 			return nil
 		}
 
-		b := backoff.NewConstant(2*time.Minute, 10*time.Second)
+		b := backoff.NewConstant(5*time.Minute, 10*time.Second)
 		n := backoff.NewNotifier(config.Logger, ctx)
 
 		err = backoff.RetryNotify(o, b, n)

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/giantswarm/apptest"
 	"github.com/giantswarm/backoff"


### PR DESCRIPTION
## Checklist

N/A

## Description

This is to mitigate the risk of `notFoundError` error we hit when app is not yet published in the catalog:

```
no app `cluster-apps-operator` in index.yaml with given appVersion `285305a6c4bb7e4bfd36254d9d78d927ad81e83c`
```