### PR TITLE
Bumping app operator version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename helm chart value `base` to `baseDomain` to improve clarity.
-- Bump app-operator to `v5.7.3`
+- Bump `app-operator` version to `v5.7.3`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename helm chart value `base` to `baseDomain` to improve clarity.
+- Bump app-operator to `v5.7.3`
 
 ### Added
 

--- a/helm/cluster-apps-operator/values.yaml
+++ b/helm/cluster-apps-operator/values.yaml
@@ -1,6 +1,6 @@
 appOperator:
   catalog: control-plane-catalog
-  version: 5.7.0
+  version: 5.7.3
 
 chartOperator:
   catalog: default


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.

Tested on `gamma`, with this new version of `app-operator` App CRs are correctly reconciled:

```yaml
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator found release `chart-operator` | app-operator/v5/service/controller/app/resource/chartoperator/create.go:102 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator release `chart-operator` deployed | app-operator/v5/service/controller/app/resource/chartoperator/create.go:136 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator triggering charts reconciliation | app-operator/v5/service/controller/app/resource/chartoperator/create.go:137 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator did not find chart `calico` in namespace `giantswarm` | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:205 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator annotating `ljak0-calico` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:206 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator annotated `ljak0-calico` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:229 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator did not find chart `cert-exporter` in namespace `giantswarm` | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:205 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator annotating `ljak0-cert-exporter` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:206 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator annotated `ljak0-cert-exporter` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:229 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator did not find chart `cloud-provider-openstack` in namespace `giantswarm` | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:205 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator annotating `ljak0-cloud-provider-openstack` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:206 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator annotated `ljak0-cloud-provider-openstack` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:229 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator did not find chart `kube-state-metrics` in namespace `giantswarm` | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:205 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator annotating `ljak0-kube-state-metrics` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:206 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator annotated `ljak0-kube-state-metrics` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:229 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator did not find chart `metrics-server` in namespace `giantswarm` | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:205 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator annotating `ljak0-metrics-server` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:206 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator annotated `ljak0-metrics-server` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:229 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator did not find chart `net-exporter` in namespace `giantswarm` | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:205 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:41 org-multi-project/ljak0-chart-operator chartoperator annotating `ljak0-net-exporter` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:206 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:42 org-multi-project/ljak0-chart-operator chartoperator annotated `ljak0-net-exporter` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:229 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:42 org-multi-project/ljak0-chart-operator chartoperator did not find chart `node-exporter` in namespace `giantswarm` | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:205 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:42 org-multi-project/ljak0-chart-operator chartoperator annotating `ljak0-node-exporter` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:206 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:42 org-multi-project/ljak0-chart-operator chartoperator annotated `ljak0-node-exporter` app | app-operator/v5/service/controller/app/resource/chartoperator/resource.go:229 | controller=app-operator-app | event=update | loop=26 | version=5303964
D 03/01 15:38:42 org-multi-project/ljak0-chart-operator chartoperator triggered charts reconciliation | app-operator/v5/service/controller/app/resource/chartoperator/create.go:146 | controller=app-operator-app | event=update | loop=26 | version=5303964
```