### PR TITLE
Fix clusterCA value location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move `clusterCA` to match the location expected by `dex-app`.
+
 ## [1.4.2] - 2022-03-01
 
 ### Changed

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -91,7 +91,6 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 			},
 			"kubernetes": map[string]interface{}{
 				"API": map[string]interface{}{
-					"clusterCA":      clusterCA,
 					"clusterIPRange": r.clusterIPRange,
 				},
 				"DNS": map[string]interface{}{
@@ -99,6 +98,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 				},
 			},
 		},
+		"clusterCA":    clusterCA,
 		"clusterDNSIP": r.dnsIP,
 		"clusterID":    key.ClusterID(&cr),
 		"clusterCIDR":  "",


### PR DESCRIPTION
Follow-up for https://github.com/giantswarm/cluster-apps-operator/pull/169. Dex chart expects `clusterCA` to be at the root of the values (see https://github.com/giantswarm/dex-app/blob/f4d88eae4ef1cb2fb27b0d1a61acaa78194b5d1c/helm/dex-app/templates/dex-k8s-authenticator/configmap-customer.yaml#L51). There are no other consumers of this value that I know of.

## Checklist

- [x] Update changelog in CHANGELOG.md.
