### PR TITLE
Bump app-operator to v5.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `app-operator` version to `v5.8.0`.
+
 ## [1.4.4] - 2022-03-09
 
 ### Changed

--- a/helm/cluster-apps-operator/values.yaml
+++ b/helm/cluster-apps-operator/values.yaml
@@ -1,6 +1,6 @@
 appOperator:
   catalog: control-plane-catalog
-  version: 5.7.5
+  version: 5.8.0
 
 chartOperator:
   catalog: default


### PR DESCRIPTION
Fix for problems found in testing on gravity.

With the latest release we generate the tarball URL for internal catalogs instead of fetching that catalogs index.yaml.

## Checklist

- [x] Update changelog in CHANGELOG.md.
