### PR TITLE
Fix backoff when waiting for app CRs to be deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix backoff when waiting for app CRs to be deleted.
+
 ## [1.4.5] - 2022-03-11
 
 ### Changed

--- a/service/controller/resource/app/delete.go
+++ b/service/controller/resource/app/delete.go
@@ -131,7 +131,7 @@ func (r Resource) waitForAppDeletion(ctx context.Context, cr capi.Cluster, appNa
 		r.logger.Errorf(ctx, err, "retrying in %s", t)
 	}
 
-	b := backoff.NewExponential(15*time.Second, 5*time.Second)
+	b := backoff.NewConstant(15*time.Second, 5*time.Second)
 	err = backoff.RetryNotify(o, b, n)
 
 	return err


### PR DESCRIPTION
While testing I noticed this backoff was doing a ton of logging.

## Checklist

- [x] Update changelog in CHANGELOG.md.
