### PR TITLE
Use right letters in cluster-values configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use right capital letters in cluster values configmap.
+
 ## [2.0.2] - 2022-09-12
 
 ### Fixed

--- a/service/controller/resource/clusterconfigmap/types.go
+++ b/service/controller/resource/clusterconfigmap/types.go
@@ -4,8 +4,8 @@ type ChartOperatorConfig struct {
 	Cni map[string]bool `json:"cni"`
 }
 type KubernetesConfig struct {
-	API map[string]string `json:"api"`
-	DNS map[string]string `json:"dns"`
+	API map[string]string `json:"API"`
+	DNS map[string]string `json:"DNS"`
 }
 type ClusterConfig struct {
 	Calico     map[string]string `json:"calico"`


### PR DESCRIPTION
It needs to match the [coredns-app values](https://github.com/giantswarm/coredns-app/blob/master/helm/coredns-app/values.yaml#L55-L63).
## Checklist

- [X] Update changelog in CHANGELOG.md.
