### PR TITLE
Deploy chart-operator with bootstrapMode enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Deploy `chart-operator` for workload clusters with enabled `bootstrapMode`.
+
 ## [2.2.0] - 2022-09-30
 
 ### Added

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -188,6 +188,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 
 	clusterValues := ClusterValuesConfig{
 		BaseDomain:    key.BaseDomain(&cr, r.baseDomain),
+		BootstrapMode: ChartOperatorBootstrapMode{Enabled: true},
 		ChartOperator: ChartOperatorConfig{Cni: map[string]bool{"install": true}},
 		Cluster: ClusterConfig{
 			Calico: map[string]string{"CIDR": podCIDR},

--- a/service/controller/resource/clusterconfigmap/desired_test.go
+++ b/service/controller/resource/clusterconfigmap/desired_test.go
@@ -108,6 +108,10 @@ func Test_ClusterValuesGCP(t *testing.T) {
 			}
 			assertEquals(t, "test-cluster.fadi.gigantic.io", cmData.BaseDomain, "Wrong baseDomain set in cluster-values configmap")
 			assertEquals(t, "12345", cmData.GcpProject, "Wrong gcpProject set in cluster-values configmap")
+
+			if !cmData.BootstrapMode.Enabled {
+				t.Fatal("bootstrap mode should be enabled")
+			}
 		}
 	}
 }

--- a/service/controller/resource/clusterconfigmap/types.go
+++ b/service/controller/resource/clusterconfigmap/types.go
@@ -1,5 +1,8 @@
 package clusterconfigmap
 
+type ChartOperatorBootstrapMode struct {
+	Enabled bool `json:"enabled"`
+}
 type ChartOperatorConfig struct {
 	Cni map[string]bool `json:"cni"`
 }
@@ -12,9 +15,11 @@ type ClusterConfig struct {
 	Kubernetes KubernetesConfig  `json:"kubernetes"`
 }
 type ClusterValuesConfig struct {
-	BaseDomain string        `json:"baseDomain"`
-	Cluster    ClusterConfig `json:"cluster"`
-	ClusterCA  string        `json:"clusterCA"`
+	BaseDomain string `json:"baseDomain"`
+	// BootstrapMode allows to configure chart-operator in bootstrap mode so that it can install charts without cni or kube-proxy.
+	BootstrapMode ChartOperatorBootstrapMode `json:"bootstrapMode"`
+	Cluster       ClusterConfig              `json:"cluster"`
+	ClusterCA     string                     `json:"clusterCA"`
 	// ClusterDNSIP is used by chart-operator. It uses this IP as its dnsConfig nameserver, to use it as resolver.
 	ClusterDNSIP  string              `json:"clusterDNSIP"`
 	ClusterID     string              `json:"clusterID"`


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1456

If we tell `kubeadm` to avoid installing `kube-proxy` then `chart-operator` can't install `cilium` because networking is not ready. We can work around this enabling the bootstrapMode on chart-operator. 

## Checklist

- [X] Update changelog in CHANGELOG.md.
