### PR TITLE
generate proxy configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 TODO
 /cluster-apps-operator
 !vendor/**
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `giantswarm.io/managed-by` label set to `flux` we check for the existence of two common Flux labels:
   `kustomize.toolkit.fluxcd.io/name` and `kustomize.toolkit.fluxcd.io/namespace` regardless of values.
 
+### Added
+
+- Generating proxy-configuration for workload clusters.
+  By defining a `proxy` configuration (`noProxy`,`httpProxy` and `httpsProxy`) in `configmap/cluster-apps-operator`, these information will be propagated into the cluster specific `configmap` and `secret`.
+  The `noProxy` value will be computed on a cluster-base as some parameters (e.g. `baseDomain` or some defined `CIDRs` might differ).
+  Apps like `cert-manager` or `chart-operator` are able to use the global configuration.
+
 ## [2.4.0] - 2022-10-17
 
 ### Changed
-
 - Enable cluster-values secret creation for CAPVCD.
 
 ## [2.3.0] - 2022-10-10

--- a/flag/service/proxy/proxy.go
+++ b/flag/service/proxy/proxy.go
@@ -1,0 +1,7 @@
+package proxy
+
+type Proxy struct {
+	NoProxy    string `json:"noProxy"`
+	HttpProxy  string `json:"http"`
+	HttpsProxy string `json:"https"`
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/app"
 	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/image"
 	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/provider"
+	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/proxy"
 	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/workload"
 )
 
@@ -16,4 +17,5 @@ type Service struct {
 	Kubernetes kubernetes.Kubernetes
 	Provider   provider.Provider
 	Workload   workload.Workload
+	Proxy      proxy.Proxy
 }

--- a/flag/service/workload/cluster/cluster.go
+++ b/flag/service/workload/cluster/cluster.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/proxy"
 	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/workload/cluster/calico"
 	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/workload/cluster/kubernetes"
 )
@@ -10,4 +11,5 @@ type Cluster struct {
 	BaseDomain string
 	Calico     calico.Calico
 	Kubernetes kubernetes.Kubernetes
+	Proxy      proxy.Proxy
 }

--- a/helm/cluster-apps-operator/templates/configmap.yaml
+++ b/helm/cluster-apps-operator/templates/configmap.yaml
@@ -30,6 +30,10 @@ data:
           keyFile: ''
       provider:
         kind: {{ .Values.provider.kind }}
+      proxy:
+        noProxy: {{ .Values.proxy.noProxy }}
+        http: {{ .Values.proxy.http }}
+        https: {{ .Values.proxy.https }}
       workload:
         cluster:
           baseDomain: '{{ .Values.baseDomain }}'

--- a/helm/cluster-apps-operator/values.yaml
+++ b/helm/cluster-apps-operator/values.yaml
@@ -11,6 +11,11 @@ baseDomain: ""
 provider:
   kind: ""
 
+proxy:
+  noProxy: ""
+  http: ""
+  https: ""
+
 cni:
   mask: 16
   subnet: 10.1.0.0
@@ -45,7 +50,7 @@ project:
 registry:
   domain: docker.io
   mirrors:
-  - giantswarm.azurecr.io
+    - giantswarm.azurecr.io
   pullSecret:
     dockerConfigJSON: ""
 

--- a/main.go
+++ b/main.go
@@ -123,6 +123,15 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Workload.Cluster.Kubernetes.API.ClusterIPRange, "", "CIDR Range for Pods in cluster.")
 	daemonCommand.PersistentFlags().String(f.Service.Workload.Cluster.Kubernetes.ClusterDomain, "cluster.local", "Internal Kubernetes domain.")
 
+	daemonCommand.PersistentFlags().String(f.Service.Proxy.NoProxy, "", "Installation specific no_proxy values.")
+	daemonCommand.PersistentFlags().String(f.Service.Proxy.HttpProxy, "", "Installation specific http_proxy value.")
+	daemonCommand.PersistentFlags().String(f.Service.Proxy.HttpsProxy, "", "Installation specific https_proxy value.")
+	/*
+		TODO:
+			* set http and https from external
+			* inject into cluster values
+	*/
+
 	err = newCommand.CobraCommand().Execute()
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -16,6 +16,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/proxy"
 	"github.com/giantswarm/cluster-apps-operator/v2/pkg/project"
 	"github.com/giantswarm/cluster-apps-operator/v2/service/controller/resource/app"
 	"github.com/giantswarm/cluster-apps-operator/v2/service/controller/resource/clusterconfigmap"
@@ -37,6 +38,7 @@ type ClusterConfig struct {
 	DNSIP                string
 	Provider             string
 	RegistryDomain       string
+	Proxy                proxy.Proxy
 }
 
 type Cluster struct {
@@ -118,6 +120,7 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 			DNSIP:          config.DNSIP,
 			Provider:       config.Provider,
 			RegistryDomain: config.RegistryDomain,
+			Proxy:          config.Proxy,
 		}
 
 		clusterConfigMapGetter, err = clusterconfigmap.New(c)
@@ -155,6 +158,7 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 		c := clustersecret.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
+			Proxy:     config.Proxy,
 		}
 
 		clusterSecretGetter, err = clustersecret.New(c)

--- a/service/controller/resource/clusterconfigmap/desired_test.go
+++ b/service/controller/resource/clusterconfigmap/desired_test.go
@@ -58,6 +58,21 @@ func Test_ClusterValuesGCP(t *testing.T) {
 				Name:       "test-cluster",
 				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
 			},
+			ClusterNetwork: &capi.ClusterNetwork{
+				ServiceDomain: "cluster.local",
+				Services: &capi.NetworkRanges{
+					CIDRBlocks: []string{
+						"192.168.10.0/24",
+						"192.168.20.0/24",
+					},
+				},
+				Pods: &capi.NetworkRanges{
+					CIDRBlocks: []string{
+						"192.168.10.0/24",
+						"192.168.20.0/24",
+					},
+				},
+			},
 		},
 	}
 

--- a/service/controller/resource/clusterconfigmap/resource.go
+++ b/service/controller/resource/clusterconfigmap/resource.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
+	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/proxy"
 	"github.com/giantswarm/cluster-apps-operator/v2/service/internal/podcidr"
 )
 
@@ -27,6 +28,7 @@ type Config struct {
 	DNSIP          string
 	Provider       string
 	RegistryDomain string
+	Proxy          proxy.Proxy
 }
 
 // Resource implements the clusterConfigMap resource.
@@ -42,6 +44,7 @@ type Resource struct {
 	dnsIP          string
 	provider       string
 	registryDomain string
+	proxy          proxy.Proxy
 }
 
 // New creates a new configured config map state getter resource managing
@@ -84,6 +87,7 @@ func New(config Config) (*Resource, error) {
 		dnsIP:          config.DNSIP,
 		provider:       config.Provider,
 		registryDomain: config.RegistryDomain,
+		proxy:          config.Proxy,
 	}
 
 	return r, nil

--- a/service/controller/resource/clustersecret/desired.go
+++ b/service/controller/resource/clustersecret/desired.go
@@ -1,8 +1,12 @@
 package clustersecret
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"html/template"
+	"reflect"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,11 +18,27 @@ import (
 	"github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 
+	capi "sigs.k8s.io/cluster-api/api/v1alpha4"
+
 	capvcd "github.com/giantswarm/cluster-apps-operator/v2/api/capvcd/v1beta1"
 
 	capo "github.com/giantswarm/cluster-apps-operator/v2/api/capo/v1alpha4"
 	"github.com/giantswarm/cluster-apps-operator/v2/pkg/project"
 	"github.com/giantswarm/cluster-apps-operator/v2/service/controller/key"
+)
+
+const (
+	mainSecretSection      = "values"
+	containerdProxySection = "containerdProxy"
+
+	containerdProxyTemplate = `[Service]
+Environment="HTTP_PROXY={{ .HttpProxy }}"
+Environment="http_proxy={{ .HttpProxy }}"
+Environment="HTTPS_PROXY={{ .HttpsProxy }}"
+Environment="https_proxy={{ .HttpsProxy }}"
+Environment="NO_PROXY={{ .NoProxy}}"
+Environment="no_proxy={{ .NoProxy }}"
+`
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*corev1.Secret, error) {
@@ -63,7 +83,6 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 					return nil, microerror.Mask(err)
 				}
 			}
-
 		}
 	}
 
@@ -71,29 +90,56 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		{
 			Name:      key.ClusterValuesResourceName(&cr),
 			Namespace: cr.GetNamespace(),
-			Values:    values,
+			Data:      map[string][]byte{},
 		},
 	}
 
-	for _, spec := range secretSpecs {
-		secret, err := newSecret(cr, spec)
-		if err != nil {
-			return nil, microerror.Mask(err)
+	if !reflect.ValueOf(r.proxy).IsZero() {
+		r.logger.Debugf(ctx, "proxy secrets for cluster '%s/%s' : %v", cr.GetNamespace(), key.ClusterID(&cr), r.proxy)
+
+		values["cluster"] = map[string]interface{}{
+			"proxy": map[string]string{
+				"noProxy": noProxy(cr, r.proxy.NoProxy),
+				"http":    r.proxy.HttpProxy,
+				"https":   r.proxy.HttpsProxy,
+			},
 		}
 
+		// template containerd proxy configuration
+		t := template.Must(template.New("systemd-proxy-template").Parse(containerdProxyTemplate))
+		var tpl bytes.Buffer
+		if err := t.Execute(&tpl, r.proxy); err != nil {
+			return nil, err
+		}
+
+		containerdProxy := tpl.String()
+
+		secretSpecs = append(secretSpecs, secretSpec{
+			Name:      fmt.Sprintf("%s-systemd-proxy", key.ClusterID(&cr)),
+			Namespace: cr.GetNamespace(),
+			Data: map[string][]byte{
+				containerdProxySection: []byte(containerdProxy),
+			},
+		})
+	}
+
+	yamlValues, err := yaml.Marshal(values)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	secretSpecs[0].Data[mainSecretSection] = []byte(yamlValues)
+
+	for _, spec := range secretSpecs {
+		secret := newSecret(cr, spec)
 		secrets = append(secrets, secret)
 	}
 
 	return secrets, nil
 }
 
-func newSecret(cr apiv1alpha3.Cluster, secretSpec secretSpec) (*corev1.Secret, error) {
-	yamlValues, err := yaml.Marshal(secretSpec.Values)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	secret := &corev1.Secret{
+func newSecret(cr apiv1alpha3.Cluster, secretSpec secretSpec) *corev1.Secret {
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretSpec.Name,
 			Namespace: secretSpec.Namespace,
@@ -105,10 +151,44 @@ func newSecret(cr apiv1alpha3.Cluster, secretSpec secretSpec) (*corev1.Secret, e
 				label.ManagedBy: project.Name(),
 			},
 		},
-		Data: map[string][]byte{
-			"values": yamlValues,
-		},
+		Data: secretSpec.Data,
+	}
+}
+
+func noProxy(cluster capi.Cluster, globalNoProxy string) string {
+
+	// generic list of noProxy
+	// will be joined with custom defined noProxy targets
+
+	var appendString []string
+	if !reflect.ValueOf(cluster.Spec.ClusterNetwork).IsZero() {
+		if !reflect.ValueOf(cluster.Spec.ClusterNetwork.ServiceDomain).IsZero() {
+			appendString = append(appendString, cluster.Spec.ClusterNetwork.ServiceDomain)
+		}
+
+		if !reflect.ValueOf(cluster.Spec.ClusterNetwork.Services).IsZero() && !reflect.ValueOf(cluster.Spec.ClusterNetwork.Services.CIDRBlocks).IsZero() {
+			appendString = append(appendString, strings.Join(cluster.Spec.ClusterNetwork.Services.CIDRBlocks, ","))
+		}
+
+		if !reflect.ValueOf(cluster.Spec.ClusterNetwork.Pods).IsZero() && !reflect.ValueOf(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks).IsZero() {
+			appendString = append(appendString, strings.Join(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks, ","))
+		}
 	}
 
-	return secret, nil
+	if !reflect.ValueOf(cluster.Spec.ControlPlaneEndpoint.Host).IsZero() {
+		appendString = append(appendString, cluster.Spec.ControlPlaneEndpoint.Host)
+	}
+
+	if len(globalNoProxy) > 0 {
+		appendString = append(appendString, globalNoProxy)
+	}
+
+	noProxy := strings.Join([]string{
+		strings.Join(appendString, ","),
+		"svc",
+		"127.0.0.1",
+		"localhost",
+	}, ",")
+
+	return noProxy
 }

--- a/service/controller/resource/clustersecret/resource.go
+++ b/service/controller/resource/clustersecret/resource.go
@@ -4,6 +4,8 @@ import (
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/proxy"
 )
 
 const (
@@ -16,12 +18,14 @@ const (
 type Config struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
+	Proxy     proxy.Proxy
 }
 
 // Resource implements the clustersecret resource.
 type Resource struct {
 	k8sClient k8sclient.Interface
 	logger    micrologger.Logger
+	proxy     proxy.Proxy
 }
 
 // New creates a new configured secret state getter resource managing
@@ -39,6 +43,7 @@ func New(config Config) (*Resource, error) {
 	r := &Resource{
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
+		proxy:     config.Proxy,
 	}
 
 	return r, nil

--- a/service/controller/resource/clustersecret/types.go
+++ b/service/controller/resource/clustersecret/types.go
@@ -3,5 +3,5 @@ package clustersecret
 type secretSpec struct {
 	Name      string
 	Namespace string
-	Values    map[string]interface{}
+	Data      map[string][]byte
 }

--- a/service/service.go
+++ b/service/service.go
@@ -21,6 +21,7 @@ import (
 	capvcd "github.com/giantswarm/cluster-apps-operator/v2/api/capvcd/v1beta1"
 	capz "github.com/giantswarm/cluster-apps-operator/v2/api/capz/v1alpha4"
 	"github.com/giantswarm/cluster-apps-operator/v2/flag"
+	"github.com/giantswarm/cluster-apps-operator/v2/flag/service/proxy"
 	"github.com/giantswarm/cluster-apps-operator/v2/pkg/project"
 	"github.com/giantswarm/cluster-apps-operator/v2/service/collector"
 	"github.com/giantswarm/cluster-apps-operator/v2/service/controller"
@@ -149,7 +150,12 @@ func New(config Config) (*Service, error) {
 			ClusterIPRange:       clusterIPRange,
 			DNSIP:                dnsIP,
 			Provider:             config.Viper.GetString(config.Flag.Service.Provider.Kind),
-			RegistryDomain:       config.Viper.GetString(config.Flag.Service.Image.Registry.Domain),
+			Proxy: proxy.Proxy{
+				HttpProxy:  config.Viper.GetString(config.Flag.Service.Proxy.HttpProxy),
+				HttpsProxy: config.Viper.GetString(config.Flag.Service.Proxy.HttpsProxy),
+				NoProxy:    config.Viper.GetString(config.Flag.Service.Proxy.NoProxy),
+			},
+			RegistryDomain: config.Viper.GetString(config.Flag.Service.Image.Registry.Domain),
 		}
 
 		var err error


### PR DESCRIPTION
additional to environment specific no proxy entries, we can generate the cluster specific values from the capi cluster cr

TODO:
- [ ] check implementation
- [x] document
- [x] update Changelog

The new behaviour with configured proxy configuration generation is documented in this RFC: https://github.com/giantswarm/rfc/blob/clusters_behind_proxy/proxy-support/README.md

## Checklist

- [x] Update changelog in CHANGELOG.md.
