### PR TITLE
generate cluster-values secret for all providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumping `chart-operator` to the `v2.32.0` version.
 - `secret/cluster-values` will be now generated for `capa`.
+- `secret/cluster-values` will now be generated for all kind of providers.
 
 ## [2.5.0] - 2022-11-10
 

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -192,19 +192,9 @@ func newClusterResources(config ClusterConfig) ([]resource.Interface, error) {
 		// clusterConfigMapResource is executed before the app resource so the
 		// app CRs are accepted by the validation webhook.
 		clusterConfigMapResource,
-	}
-
-	if config.Provider == "openstack" || config.Provider == "cloud-director" || config.Provider == "capa" {
-		// clusterSecretResource is executed before the app resource so the
-		// app CRs are accepted by the validation webhook.
-		resources = append(resources, clusterSecretResource)
-	}
-
-	resources = append(resources,
-		// appResource manages the per cluster app-operator instance and the
-		// workload cluster apps.
+		clusterSecretResource,
 		appResource,
-	)
+	}
 
 	{
 		c := retryresource.WrapConfig{


### PR DESCRIPTION
I can't see a valid reason why we shouldn't create the `cluster-values` secret for all clusters.
In a bad case, the secret might be empty but as we merge the `secret` and the `configmap` into the values, this shouldn't be a problem.


## Checklist

- [x] Update changelog in CHANGELOG.md.
