### PR TITLE
Enable private clusters for on-premise providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable private clusters for cloud-director, openstack and vsphere.
+
 ## [2.8.2] - 2022-11-29
 
 ### Changed

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -3,6 +3,7 @@ package clusterconfigmap
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/k8smetadata/pkg/label"
@@ -147,8 +148,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 				}
 
 				privateCluster = annotationValue == annotation.AWSVPCModePrivate
-			case "openstack":
-			case "vsphere":
+			case "cloud-director", "openstack", "vsphere":
+				privateCluster = !reflect.ValueOf(r.proxy).IsZero()
 			case "gcp":
 				gcpCluster := &unstructured.Unstructured{}
 				gcpCluster.SetGroupVersionKind(schema.GroupVersionKind{


### PR DESCRIPTION
AWS uses annotations on the CR. For on-prem providers, we don't have such an annotation. When proxy is enabled, it means the cluster is a private cluster.

See https://github.com/giantswarm/cluster-apps-operator/blob/master/service/controller/resource/clustersecret/desired.go#L164

## Checklist

- [x] Update changelog in CHANGELOG.md.
