### PR TITLE
Add empty `case for capz` to stop error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enable private clusters for cloud-director, openstack and vsphere.
 - Added the use of the runtime/default seccomp profile.
+- Add empty case for `capz` in the configmap special handling to stop error in the logs
 
 ## [2.8.2] - 2022-11-29
 

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -126,6 +126,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 				if len(blocks) > 0 {
 					clusterCIDR = blocks[0]
 				}
+			case "capz":
 			case "aws":
 			case "capa":
 				awsCluster := &unstructured.Unstructured{}


### PR DESCRIPTION
we don't need any special handling for `capz` but the error it prints can be misleading when troubleshooting something else

## Checklist

- [x] Update changelog in CHANGELOG.md.
