### PR TITLE
bump-chart-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `chart-operator` to version `v2.35.1`.
+
 ## [2.14.0] - 2023-09-11
 
 ### Added

--- a/helm/cluster-apps-operator/values.yaml
+++ b/helm/cluster-apps-operator/values.yaml
@@ -4,7 +4,7 @@ appOperator:
 
 chartOperator:
   catalog: default-test
-  version: 2.35.0-5f8b0294d73c5b4e38de15e7f7a8b7fd9fa1491c
+  version: 2.35.0-1aa7f36dab0598352f8d0ef7d7f4774405914431
 
 baseDomain: ""
 

--- a/helm/cluster-apps-operator/values.yaml
+++ b/helm/cluster-apps-operator/values.yaml
@@ -4,7 +4,7 @@ appOperator:
 
 chartOperator:
   catalog: default-test
-  version: 2.35.0-1aa7f36dab0598352f8d0ef7d7f4774405914431
+  version: 2.35.0-c2e9f30d5f955a312bd5dd4e57ab766100f2ccaf
 
 baseDomain: ""
 

--- a/helm/cluster-apps-operator/values.yaml
+++ b/helm/cluster-apps-operator/values.yaml
@@ -3,8 +3,8 @@ appOperator:
   version: 6.6.4
 
 chartOperator:
-  catalog: default-test
-  version: 2.35.0-c2e9f30d5f955a312bd5dd4e57ab766100f2ccaf
+  catalog: default
+  version: 2.35.1
 
 baseDomain: ""
 

--- a/helm/cluster-apps-operator/values.yaml
+++ b/helm/cluster-apps-operator/values.yaml
@@ -3,8 +3,8 @@ appOperator:
   version: 6.6.4
 
 chartOperator:
-  catalog: default
-  version: 2.33.0
+  catalog: default-test
+  version: 2.35.0-5f8b0294d73c5b4e38de15e7f7a8b7fd9fa1491c
 
 baseDomain: ""
 


### PR DESCRIPTION
include changes to chart-operator taints necessary for migration from Vintage to CAPI