### PR TITLE
Bump app-operator and chart-operator in order to use image registry `gsoci.azurecr.io`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The provider information source of truth is changed from the configuration option to Cluster CRs.
+- Update `app-operator` to version `6.10.3` (uses image registry `gsoci.azurecr.io`).
+- Update `chart-operator` to version `3.1.3` (uses image registry `gsoci.azurecr.io`).
 
 ## [2.18.1] - 2024-01-29
 

--- a/helm/cluster-apps-operator/values.yaml
+++ b/helm/cluster-apps-operator/values.yaml
@@ -1,10 +1,14 @@
 appOperator:
   catalog: control-plane-catalog
-  version: 6.10.0
+  # used by renovate
+  # repo: giantswarm/app-operator
+  version: 6.10.3
 
 chartOperator:
   catalog: default
-  version: 3.1.0
+  # used by renovate
+  # repo: giantswarm/chart-operator
+  version: 3.1.3
 
 baseDomain: ""
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3168 and https://github.com/giantswarm/roadmap/issues/3169. Also affects Vintage, I think.

I added a renovate config – let me know if that makes any sense.

## Checklist

- [x] Update changelog in CHANGELOG.md.
