### PR TITLE
Add missing team label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing team label to alls resources and especially the servicemonitor.
+
 ## [2.20.1] - 2024-02-14
 
 ### Fixed

--- a/helm/cluster-apps-operator/templates/_helpers.tpl
+++ b/helm/cluster-apps-operator/templates/_helpers.tpl
@@ -23,6 +23,7 @@ app.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | replace 
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}
 


### PR DESCRIPTION
Add team label to helpers so service-monitor can be picked up by the prometheus-agents

## Checklist

- [ ] Update changelog in CHANGELOG.md.
