### PR TITLE
set external dns ip to empty value in all vsphere clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `ExternalDNSIP` to an empty value in the cluster values configmap for all vsphere clusters.
+
 ## [3.0.0] - 2024-11-19
 
 ### Removed

--- a/service/controller/resource/clusterconfigmap/desired.go
+++ b/service/controller/resource/clusterconfigmap/desired.go
@@ -268,10 +268,10 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) ([]*cor
 		}
 	}
 
-	// if we explicitly set externalDNSIP to "" it will cause to install chart-operator in mode that is compatible with private clusters
+	// if we explicitly set externalDNSIP to "" it will cause to install chart-operator in mode that is compatible with private clusters and all vsphere clusters
 	// as externalDNSIP is used as test DNS and default value is public google dns, but there isn't any value that could be used in private clusters
 	// as the cloud providers have unpredictable DNS ip depending on which subnet is the machine and pod running.
-	if privateCluster {
+	if privateCluster || provider == infra.VSphereClusterKindProvider {
 		emptyValue := ""
 		clusterValues.ExternalDNSIP = &emptyValue
 		clusterValues.Cluster.Private = true


### PR DESCRIPTION
Even if a vsphere cluster is not using a proxy and therefore not considered a private cluster we want to prevent the external dns ip to be set to the default value.
## Checklist

- [ ] Update changelog in CHANGELOG.md.
